### PR TITLE
Sample project bugfix (missing CXMLNamespaceNode.h / .m)

### DIFF
--- a/Sample Project/Simple KML Example.xcodeproj/project.pbxproj
+++ b/Sample Project/Simple KML Example.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		2899E5220DE3E06400AC0155 /* Simple_KML_ExampleViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2899E5210DE3E06400AC0155 /* Simple_KML_ExampleViewController.xib */; };
 		28AD733F0D9D9553002E5188 /* MainWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 28AD733E0D9D9553002E5188 /* MainWindow.xib */; };
 		28D7ACF80DDB3853001CB0EB /* Simple_KML_ExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 28D7ACF70DDB3853001CB0EB /* Simple_KML_ExampleViewController.m */; };
+		640B08A813A0077400DC40C3 /* CXMLNamespaceNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 640B08A713A0077400DC40C3 /* CXMLNamespaceNode.m */; };
 		DD4CEFFB124AAC4800597565 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD4CEFFA124AAC4800597565 /* MapKit.framework */; };
 		DD4CF546124AAF2B00597565 /* ioapi.c in Sources */ = {isa = PBXBuildFile; fileRef = DD4CF4D4124AAF2B00597565 /* ioapi.c */; };
 		DD4CF547124AAF2B00597565 /* mztools.c in Sources */ = {isa = PBXBuildFile; fileRef = DD4CF4D6124AAF2B00597565 /* mztools.c */; };
@@ -86,6 +87,8 @@
 		28D7ACF70DDB3853001CB0EB /* Simple_KML_ExampleViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Simple_KML_ExampleViewController.m; sourceTree = "<group>"; };
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		32CA4F630368D1EE00C91783 /* Simple_KML_Example_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Simple_KML_Example_Prefix.pch; sourceTree = "<group>"; };
+		640B08A613A0077400DC40C3 /* CXMLNamespaceNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CXMLNamespaceNode.h; sourceTree = "<group>"; };
+		640B08A713A0077400DC40C3 /* CXMLNamespaceNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CXMLNamespaceNode.m; sourceTree = "<group>"; };
 		8D1107310486CEB800E47090 /* Simple_KML_Example-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Simple_KML_Example-Info.plist"; plistStructureDefinitionIdentifier = "com.apple.xcode.plist.structure-definition.iphone.info-plist"; sourceTree = "<group>"; };
 		DD4CEFFA124AAC4800597565 /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
 		DD4CF00B124AACA900597565 /* example.kml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = example.kml; sourceTree = "<group>"; };
@@ -423,6 +426,8 @@
 				DD4CF51F124AAF2B00597565 /* CXMLElement_CreationExtensions.m */,
 				DD4CF520124AAF2B00597565 /* CXMLElement_ElementTreeExtensions.h */,
 				DD4CF521124AAF2B00597565 /* CXMLElement_ElementTreeExtensions.m */,
+				640B08A613A0077400DC40C3 /* CXMLNamespaceNode.h */,
+				640B08A713A0077400DC40C3 /* CXMLNamespaceNode.m */,
 				DD4CF522124AAF2B00597565 /* CXMLNode.h */,
 				DD4CF523124AAF2B00597565 /* CXMLNode.m */,
 				DD4CF524124AAF2B00597565 /* CXMLNode_PrivateExtensions.h */,
@@ -484,7 +489,11 @@
 			isa = PBXProject;
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "Simple KML Example" */;
 			compatibilityVersion = "Xcode 3.1";
+			developmentRegion = English;
 			hasScannedForEncodings = 1;
+			knownRegions = (
+				en,
+			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -568,6 +577,7 @@
 				DD4CF57A124AAF2B00597565 /* SimpleKMLGeometry.m in Sources */,
 				DD4CF57B124AAF2B00597565 /* SimpleKMLFolder.m in Sources */,
 				DD4CF57C124AAF2B00597565 /* SimpleKML_UIImage.m in Sources */,
+				640B08A813A0077400DC40C3 /* CXMLNamespaceNode.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -587,6 +597,7 @@
 				INFOPLIST_FILE = "Simple_KML_Example-Info.plist";
 				OTHER_LDFLAGS = "-lxml2";
 				PRODUCT_NAME = "Simple KML Example";
+				SDKROOT = iphoneos;
 			};
 			name = Debug;
 		};
@@ -601,6 +612,7 @@
 				INFOPLIST_FILE = "Simple_KML_Example-Info.plist";
 				OTHER_LDFLAGS = "-lxml2";
 				PRODUCT_NAME = "Simple KML Example";
+				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;


### PR DESCRIPTION
Added CXMLNamespaceNode.h and CXMLNamespaceNode.m to sample project
Updated project to use "latest Build" in build settings
