### PR TITLE
Fixed double release crasher in SimpleKMLPolygon

### DIFF
--- a/SimpleKMLPolygon.m
+++ b/SimpleKMLPolygon.m
@@ -130,7 +130,6 @@
 - (void)dealloc
 {
     [outerBoundary release];
-    [firstInnerBoundary release];
     [innerBoundaries release];
     
     [super dealloc];


### PR DESCRIPTION
In the file SimpleKMLPolygon.h, firstInnerBoundary is declared as an assign property, but it was getting released in dealloc, which caused a double release of the first object (and a subsequent crash) when the innerBoundaries array was subsequently released.
