### PR TITLE
Fix for issue #9 (Memory leak fix). Memory leak caused by bug in the code

### DIFF
--- a/SimpleKMLLineString.m
+++ b/SimpleKMLLineString.m
@@ -53,7 +53,7 @@
             {
                 NSMutableArray *parsedCoordinates = [NSMutableArray array];
                 
-                NSArray *coordinateStrings = [[child stringValue] componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+                NSArray *coordinateStrings = [[child stringValue] componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
                 
                 for (NSString *coordinateString in coordinateStrings)
                 {


### PR DESCRIPTION
Fix for issue #9 (Memory leak fix). Memory leak caused by bug in the code.

If you are processing KML with LineString, use this fix. I found this when a multigeometry element contains LineString, though the same issue would arise with simplegeometry as well.
