### PR TITLE
Fix crash when attempting to open an empty file

### DIFF
--- a/source/SimpleKML.m
+++ b/source/SimpleKML.m
@@ -103,7 +103,15 @@
             
             return nil;
         }
-        
+      
+        if (!source.length)
+        {
+            NSDictionary *userInfo = [NSDictionary dictionaryWithObject:@"Empty file"
+                                                             forKey:NSLocalizedFailureReasonErrorKey];
+            *error = [NSError errorWithDomain:SimpleKMLErrorDomain code:SimpleKMLParseError userInfo:userInfo];
+            return nil;
+        }
+      
         NSError *parseError = nil;
         
         CXMLDocument *document = [[CXMLDocument alloc] initWithXMLString:source


### PR DESCRIPTION
The crash actually happens in CMXMLDocument.m, because it's not checking if the result of xmlGetLastError() is NULL, but if CMXMLDocument only works with non-empty strings, then it shouldn't get passed an empty string.